### PR TITLE
table: support checksum modes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,11 @@ on:
   push:
     branches:
     - master
+    - develop
   pull_request:
     branches:
     - master
+    - develop
     
 name: Test
 

--- a/benches/bench_table.rs
+++ b/benches/bench_table.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use agatedb::opt::ChecksumVerificationMode::NoVerification;
+use agatedb::ChecksumVerificationMode::NoVerification;
 use agatedb::{Table, TableBuilder, TableOptions, Value};
 use bytes::Bytes;
 use common::rand_value;

--- a/benches/bench_table.rs
+++ b/benches/bench_table.rs
@@ -1,5 +1,6 @@
 mod common;
 
+use agatedb::opt::ChecksumVerificationMode::NoVerification;
 use agatedb::{Table, TableBuilder, TableOptions, Value};
 use bytes::Bytes;
 use common::rand_value;
@@ -24,6 +25,7 @@ fn bench_table_builder(c: &mut Criterion) {
             block_size: 4 * 1024,
             bloom_false_positive: 0.01,
             table_size: 5 << 20,
+            checksum_mode: NoVerification,
         };
 
         b.iter(|| {
@@ -44,6 +46,7 @@ fn get_table_for_benchmark(count: usize) -> Table {
         block_size: 4 * 1024,
         bloom_false_positive: 0.01,
         table_size: 0,
+        checksum_mode: NoVerification,
     };
 
     let mut builder = TableBuilder::new(opts.clone());
@@ -75,6 +78,7 @@ fn bench_table(c: &mut Criterion) {
         block_size: 4 * 1024,
         bloom_false_positive: 0.01,
         table_size: 0,
+        checksum_mode: NoVerification,
     };
 
     c.bench_function("table read and build", |b| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ mod format;
 mod levels;
 mod memtable;
 mod ops;
-mod opt;
+pub mod opt;
 mod table;
 mod util;
 mod value;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,8 @@ mod value;
 mod wal;
 
 pub use format::{get_ts, key_with_ts};
-pub use opt::Options as TableOptions;
 pub use opt::ChecksumVerificationMode;
+pub use opt::Options as TableOptions;
 pub use table::builder::Builder as TableBuilder;
 pub use table::Table;
 pub use value::Value;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ mod format;
 mod levels;
 mod memtable;
 mod ops;
-pub mod opt;
+mod opt;
 mod table;
 mod util;
 mod value;
@@ -15,6 +15,7 @@ mod wal;
 
 pub use format::{get_ts, key_with_ts};
 pub use opt::Options as TableOptions;
+pub use opt::ChecksumVerificationMode;
 pub use table::builder::Builder as TableBuilder;
 pub use table::Table;
 pub use value::Value;

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -6,4 +6,16 @@ pub struct Options {
     pub block_size: usize,
     /// false positive probability of bloom filter
     pub bloom_false_positive: f64,
+    /// checksum mode
+    pub checksum_mode: ChecksumVerificationMode
+}
+#[derive(Debug, Clone)]
+pub enum ChecksumVerificationMode {
+    NoVerification,
+	OnTableRead,
+	// OnBlockRead indicates checksum should be verified on every SSTable block read.
+	OnBlockRead,
+	// OnTableAndBlockRead indicates checksum should be verified
+	// on SSTable opening and on every block read.
+	OnTableAndBlockRead
 }

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -7,15 +7,15 @@ pub struct Options {
     /// false positive probability of bloom filter
     pub bloom_false_positive: f64,
     /// checksum mode
-    pub checksum_mode: ChecksumVerificationMode
+    pub checksum_mode: ChecksumVerificationMode,
 }
 #[derive(Debug, Clone)]
 pub enum ChecksumVerificationMode {
     NoVerification,
-	OnTableRead,
-	// OnBlockRead indicates checksum should be verified on every SSTable block read.
-	OnBlockRead,
-	// OnTableAndBlockRead indicates checksum should be verified
-	// on SSTable opening and on every block read.
-	OnTableAndBlockRead
+    OnTableRead,
+    // OnBlockRead indicates checksum should be verified on every SSTable block read.
+    OnBlockRead,
+    // OnTableAndBlockRead indicates checksum should be verified
+    // on SSTable opening and on every block read.
+    OnTableAndBlockRead,
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -128,11 +128,11 @@ impl TableInner {
             index: TableIndex::default(),
             index_start: 0,
             index_len: 0,
-            opts: opts.clone(),
+            opts: opts,
         };
         inner.init_biggest_and_smallest()?;
 
-        if matches!(opts.checksum_mode, OnTableAndBlockRead | OnTableRead) {
+        if matches!(inner.opts.checksum_mode, OnTableAndBlockRead | OnTableRead) {
             inner.verify_checksum()?;
         }
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -284,7 +284,7 @@ impl TableInner {
             checksum,
         });
 
-        if matches!(self.opts.checksum_mode, OnTableAndBlockRead | OnTableRead) {
+        if matches!(self.opts.checksum_mode, OnTableAndBlockRead | OnBlockRead) {
             blk.verify_checksum()?;
         }
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -146,7 +146,7 @@ impl TableInner {
         let table_size = data.len();
         let mut inner = TableInner {
             file: MmapFile::Memory { data },
-            opts: opts.clone(),
+            opts,
             table_size,
             id,
             smallest: Bytes::new(),
@@ -159,7 +159,7 @@ impl TableInner {
         };
         inner.init_biggest_and_smallest()?;
 
-        if matches!(opts.checksum_mode, OnTableAndBlockRead | OnTableRead) {
+        if matches!(inner.opts.checksum_mode, OnTableAndBlockRead | OnTableRead) {
             inner.verify_checksum()?;
         }
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -123,7 +123,7 @@ impl TableInner {
             opts,
         };
         inner.init_biggest_and_smallest()?;
-        // TODO: verify checksum
+        inner.verify_checksum()?;
         Ok(inner)
     }
 
@@ -144,6 +144,7 @@ impl TableInner {
             index_len: 0,
         };
         inner.init_biggest_and_smallest()?;
+        inner.verify_checksum()?;
         Ok(inner)
     }
 
@@ -331,7 +332,7 @@ impl TableInner {
         let table_index = self.fetch_index();
         for i in 0..table_index.offsets.len() {
             let block = self.block(i, true)?;
-            // TODO: table opts
+            // TODO: use table opts to determine whether to verify checksum now
             block.verify_checksum()?;
         }
         Ok(())

--- a/src/table.rs
+++ b/src/table.rs
@@ -128,7 +128,7 @@ impl TableInner {
             index: TableIndex::default(),
             index_start: 0,
             index_len: 0,
-            opts: opts,
+            opts,
         };
         inner.init_biggest_and_smallest()?;
 

--- a/src/table/builder.rs
+++ b/src/table/builder.rs
@@ -214,7 +214,7 @@ mod tests {
             block_size: 4 * 1024,
             bloom_false_positive: 0.01,
             table_size: 30 << 20,
-            checksum_mode: crate::opt::ChecksumVerificationMode::OnTableAndBlockRead
+            checksum_mode: crate::opt::ChecksumVerificationMode::OnTableAndBlockRead,
         };
 
         let mut builder = Builder::new(opts.clone());
@@ -262,7 +262,7 @@ mod tests {
             bloom_false_positive: 0.1,
             block_size: 0,
             table_size: 0,
-            checksum_mode: crate::opt::ChecksumVerificationMode::NoVerification
+            checksum_mode: crate::opt::ChecksumVerificationMode::NoVerification,
         };
 
         let mut b = Builder::new(opt);

--- a/src/table/builder.rs
+++ b/src/table/builder.rs
@@ -214,6 +214,7 @@ mod tests {
             block_size: 4 * 1024,
             bloom_false_positive: 0.01,
             table_size: 30 << 20,
+            checksum_mode: crate::opt::ChecksumVerificationMode::OnTableAndBlockRead
         };
 
         let mut builder = Builder::new(opts.clone());
@@ -261,6 +262,7 @@ mod tests {
             bloom_false_positive: 0.1,
             block_size: 0,
             table_size: 0,
+            checksum_mode: crate::opt::ChecksumVerificationMode::NoVerification
         };
 
         let mut b = Builder::new(opt);

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -360,7 +360,8 @@ fn test_table_big_values() {
 #[test]
 fn test_table_checksum() {
     let mut rng = thread_rng();
-    let opts = get_test_table_options();
+    let mut opts = get_test_table_options();
+    opts.checksum_mode = ChecksumVerificationMode::OnTableAndBlockRead;
     let kv_pairs = generate_table_data(b"k", 10000, opts.clone());
     let mut table_data = build_table_data(kv_pairs, opts.clone()).to_vec();
     let start = rng.gen_range(0, table_data.len() - 100);

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -4,8 +4,8 @@ use super::*;
 use crate::format::{key_with_ts, user_key};
 use crate::value::Value;
 use builder::Builder;
-use rand::prelude::*;
 use iterator::IteratorError;
+use rand::prelude::*;
 use tempdir::TempDir;
 
 fn key(prefix: &[u8], i: usize) -> Bytes {
@@ -31,7 +31,6 @@ fn get_test_table_options() -> Options {
 }
 
 fn generate_table_data(prefix: &[u8], n: usize, mut opts: Options) -> Vec<(Bytes, Bytes)> {
-fn build_test_table(prefix: &[u8], n: usize, mut opts: Options) -> TableGuard {
     if opts.block_size == 0 {
         opts.block_size = 4 * 1024;
     }
@@ -48,7 +47,7 @@ fn build_test_table(prefix: &[u8], n: usize, mut opts: Options) -> TableGuard {
     kv_pairs
 }
 
-fn build_test_table(prefix: &[u8], n: usize, opts: Options) -> Table {
+fn build_test_table(prefix: &[u8], n: usize, opts: Options) -> TableGuard {
     let kv_pairs = generate_table_data(prefix, n, opts.clone());
     build_table(kv_pairs, opts)
 }
@@ -76,8 +75,7 @@ impl DerefMut for TableGuard {
     }
 }
 
-fn build_table(mut kv_pairs: Vec<(Bytes, Bytes)>, opts: Options) -> TableGuard {
-    let mut builder = Builder::new(opts.clone());
+fn build_table(kv_pairs: Vec<(Bytes, Bytes)>, opts: Options) -> TableGuard {
     let tmp_dir = TempDir::new("agatedb").unwrap();
     let filename = tmp_dir.path().join("1.sst".to_string());
 

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::format::{key_with_ts, user_key};
 use crate::value::Value;
 use builder::Builder;
+use rand::prelude::*;
 use tempdir::TempDir;
 
 fn key(prefix: &[u8], i: usize) -> Bytes {
@@ -22,10 +23,11 @@ fn get_test_table_options() -> Options {
         block_size: 4 * 1024,
         table_size: 0,
         bloom_false_positive: 0.01,
+        checksum_mode: ChecksumVerificationMode::OnTableRead,
     }
 }
 
-fn build_test_table(prefix: &[u8], n: usize, mut opts: Options) -> Table {
+fn generate_table_data(prefix: &[u8], n: usize, mut opts: Options) -> Vec<(Bytes, Bytes)> {
     if opts.block_size == 0 {
         opts.block_size = 4 * 1024;
     }
@@ -39,20 +41,19 @@ fn build_test_table(prefix: &[u8], n: usize, mut opts: Options) -> Table {
         kv_pairs.push((k, v));
     }
 
+    kv_pairs
+}
+
+fn build_test_table(prefix: &[u8], n: usize, opts: Options) -> Table {
+    let kv_pairs = generate_table_data(prefix, n, opts.clone());
     build_table(kv_pairs, opts)
 }
 
-fn build_table(mut kv_pairs: Vec<(Bytes, Bytes)>, opts: Options) -> Table {
-    let mut builder = Builder::new(opts.clone());
+fn build_table(kv_pairs: Vec<(Bytes, Bytes)>, opts: Options) -> Table {
     let tmp_dir = TempDir::new("agatedb").unwrap();
     let filename = tmp_dir.path().join("1.sst".to_string());
 
-    kv_pairs.sort_by(|x, y| x.0.cmp(&y.0));
-
-    for (k, v) in kv_pairs {
-        builder.add(&key_with_ts(&k[..], 0), Value::new_with_meta(v, b'A', 0), 0);
-    }
-    let data = builder.finish();
+    let data = build_table_data(kv_pairs, opts.clone());
 
     Table::create(&filename, data, opts).unwrap()
     // you can also test in-memory table
@@ -60,6 +61,16 @@ fn build_table(mut kv_pairs: Vec<(Bytes, Bytes)>, opts: Options) -> Table {
     // `tmp_dir` will be dropped and the temp folder will be deleted
     // when we return from this function. However, as we saves file
     // descriptor to the file, we could still safely access that file.
+}
+
+fn build_table_data(mut kv_pairs: Vec<(Bytes, Bytes)>, opts: Options) -> Bytes {
+    let mut builder = Builder::new(opts);
+    kv_pairs.sort_by(|x, y| x.0.cmp(&y.0));
+
+    for (k, v) in kv_pairs {
+        builder.add(&key_with_ts(&k[..], 0), Value::new_with_meta(v, b'A', 0), 0);
+    }
+    builder.finish()
 }
 
 #[test]
@@ -312,6 +323,7 @@ fn test_table_big_values() {
         block_size: 4 * 1024,
         bloom_false_positive: 0.01,
         table_size: (n as u64) * (1 << 20),
+        checksum_mode: ChecksumVerificationMode::OnTableRead,
     };
     let mut builder = Builder::new(opts.clone());
 
@@ -343,4 +355,18 @@ fn test_table_big_values() {
     assert_eq!(n, count);
     // TODO: support max_version in table
     // assert_eq!(n, table.max_version());
+}
+
+#[test]
+fn test_table_checksum() {
+    let mut rng = thread_rng();
+    let opts = get_test_table_options();
+    let kv_pairs = generate_table_data(b"k", 10000, opts.clone());
+    let mut table_data = build_table_data(kv_pairs, opts.clone()).to_vec();
+    let start = rng.gen_range(0, table_data.len() - 100);
+    rng.fill_bytes(&mut table_data[start..start + 100]);
+    assert!(matches!(
+        Table::open_in_memory(Bytes::from(table_data), 233, opts),
+        Err(Error::InvalidChecksum(_))
+    ));
 }


### PR DESCRIPTION
Will be ready for review when table implementation has been merged.

I plan to support all badger checksum options `ChecksumVerificationMode` in this PR

```go
const (
	// NoVerification indicates DB should not verify checksum for SSTable blocks.
	NoVerification ChecksumVerificationMode = iota
	// OnTableRead indicates checksum should be verified while opening SSTtable.
	OnTableRead
	// OnBlockRead indicates checksum should be verified on every SSTable block read.
	OnBlockRead
	// OnTableAndBlockRead indicates checksum should be verified
	// on SSTable opening and on every block read.
	OnTableAndBlockRead
)
```

Signed-off-by: Alex Chi <iskyzh@gmail.com>