### PR TITLE
skiplist: Fix undefined behavior in arena drop

### DIFF
--- a/skiplist/src/arena.rs
+++ b/skiplist/src/arena.rs
@@ -11,7 +11,9 @@ struct ArenaCore {
 impl Drop for ArenaCore {
     fn drop(&mut self) {
         unsafe {
-            Vec::from_raw_parts(self.ptr, 0, self.cap);
+            let ptr = self.ptr as *mut u64;
+            let cap = self.cap / 8;
+            Vec::from_raw_parts(ptr, 0, cap);
         }
     }
 }


### PR DESCRIPTION
The Vec must be deallocated with the same pointer alignment and capacity as it
is created.

Signed-off-by: Brian Anderson <andersrb@gmail.com>

Found with miri cc @RalfJung