### PR TITLE
skl: replace AtomicU32 with AtomicPtr

### DIFF
--- a/skiplist/src/arena.rs
+++ b/skiplist/src/arena.rs
@@ -53,7 +53,7 @@ impl Arena {
         unsafe { self.get_mut(ptr_offset as u32) as _ }
     }
 
-    pub unsafe fn get_mut<N>(&self, offset: u32) -> *mut N {
+    unsafe fn get_mut<N>(&self, offset: u32) -> *mut N {
         if offset == 0 {
             return ptr::null_mut();
         }

--- a/skiplist/src/list.rs
+++ b/skiplist/src/list.rs
@@ -202,7 +202,6 @@ impl<C: KeyComparator> Skiplist<C> {
                     next[i] = n;
                     assert_ne!(p, n);
                 }
-                // let next_offset = self.core.arena.offset(next[i]);
                 x.tower[i].store(next[i], Ordering::SeqCst);
                 match unsafe { &*prev[i] }.tower[i].compare_exchange(
                     next[i],


### PR DESCRIPTION
This PR uses `AtomicPtr` instead of `AtomicU32` in the skiplist, which simplifies some handing
Signed-off-by: Fullstop000 <fullstop1005@gmail.com>