### PR TITLE
*: lock syn version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ memmap = "0.7"
 farmhash = "1.1"
 prost = "0.7"
 enum_dispatch = "0.3"
+syn = { version = "= 1.0.57", features = ["full", "extra-traits"] }
 
 [dev-dependencies]
 criterion = "0.3"


### PR DESCRIPTION
`enum_dispatch` is broken with latest `syn` release `1.0.58`. To make our crate compile, we should make cargo resolver to use `syn` of `1.0.57` until `enum_dispatch` upgrades.

https://gitlab.com/antonok/enum_dispatch/-/issues/37

Signed-off-by: Alex Chi <iskyzh@gmail.com>