### PR TITLE
skiplist: migrate bench to bytes 1.0

### DIFF
--- a/skiplist/benches/bench.rs
+++ b/skiplist/benches/bench.rs
@@ -32,7 +32,7 @@ fn append_ts(key: &mut BytesMut, ts: u64) {
 fn random_key(rng: &mut ThreadRng) -> Bytes {
     let mut key = BytesMut::with_capacity(16);
     unsafe {
-        rng.fill_bytes(mem::transmute(&mut key.bytes_mut()[..8]));
+        rng.fill_bytes(mem::transmute(&mut key.chunk_mut()[..8]));
         key.advance_mut(8);
     }
     append_ts(&mut key, 0);


### PR DESCRIPTION
`bytes_mut` has been replaced by `chunk_mut` in `bytes` v1.0.

Signed-off-by: Alex Chi <iskyzh@gmail.com>