### PR TITLE
*: bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,14 @@ crc = "1.8"
 rand = "0.7"
 proto = { path = "proto" }
 skiplist = { path = "skiplist" }
-memmap = "0.7"
+memmap2 = "0.3"
 farmhash = "1.1"
-prost = "0.7"
+prost = "0.8"
 enum_dispatch = "0.3"
 
 [dev-dependencies]
 criterion = "0.3"
-tempdir = "0.3"
+tempfile = "3"
 
 [target.'cfg(not(target_env = "msvc"))'.dev-dependencies]
 tikv-jemallocator = "0.4.0"

--- a/benches/bench_table.rs
+++ b/benches/bench_table.rs
@@ -9,7 +9,7 @@ use bytes::Bytes;
 use common::rand_value;
 use criterion::{criterion_group, criterion_main, Criterion};
 use rand::Rng;
-use tempdir::TempDir;
+use tempfile::{tempdir, TempDir};
 
 fn bench_table_builder(c: &mut Criterion) {
     c.bench_function("table builder", |b| {
@@ -65,7 +65,7 @@ impl DerefMut for TableGuard {
 }
 
 fn get_table_for_benchmark(count: usize) -> TableGuard {
-    let tmp_dir = TempDir::new("agatedb").unwrap();
+    let tmp_dir = tempdir().unwrap();
 
     let opts = TableOptions {
         // TODO: add compression parameter

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 bytes = "1.0"
-prost = "0.7"
+prost = "0.8"
 
 [build-dependencies]
-prost-build = { version = "0.7" }
+prost-build = { version = "0.8" }

--- a/src/table.rs
+++ b/src/table.rs
@@ -17,7 +17,7 @@ use crate::Result;
 use iterator::{TableRefIterator, ITERATOR_NOCACHE, ITERATOR_REVERSED};
 
 use bytes::{Buf, Bytes};
-use memmap::{Mmap, MmapOptions};
+use memmap2::{Mmap, MmapOptions};
 use prost::Message;
 use proto::meta::{BlockOffset, Checksum, TableIndex};
 use std::fs;

--- a/src/table/builder.rs
+++ b/src/table/builder.rs
@@ -213,7 +213,7 @@ mod tests {
     use crate::table::Table;
     use crate::AgateIterator;
     use crate::{format::key_with_ts, ChecksumVerificationMode};
-    use tempdir::TempDir;
+    use tempfile::tempdir;
 
     const TEST_KEYS_COUNT: usize = 100000;
 
@@ -228,7 +228,7 @@ mod tests {
         };
 
         let mut builder = Builder::new(opts.clone());
-        let tmp_dir = TempDir::new("agatedb").unwrap();
+        let tmp_dir = tempdir().unwrap();
         let filename = tmp_dir.path().join("1.sst".to_string());
 
         let mut block_first_keys = vec![];

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -6,7 +6,7 @@ use crate::value::Value;
 use builder::Builder;
 use iterator::IteratorError;
 use rand::prelude::*;
-use tempdir::TempDir;
+use tempfile::{tempdir, TempDir};
 
 fn key(prefix: &[u8], i: usize) -> Bytes {
     Bytes::from([prefix, format!("{:04}", i).as_bytes()].concat())
@@ -79,7 +79,7 @@ impl DerefMut for TableGuard {
 }
 
 fn build_table(kv_pairs: Vec<(Bytes, Bytes)>, opts: Options) -> TableGuard {
-    let tmp_dir = TempDir::new("agatedb").unwrap();
+    let tmp_dir = tempdir().unwrap();
     let filename = tmp_dir.path().join("1.sst".to_string());
 
     let data = build_table_data(kv_pairs, opts.clone());
@@ -362,7 +362,7 @@ fn test_table_big_values() {
         builder.add(&key, vs, 0);
     }
 
-    let tmp_dir = TempDir::new("agatedb").unwrap();
+    let tmp_dir = tempdir().unwrap();
     let filename = tmp_dir.path().join("1.sst".to_string());
 
     let table = Table::create(&filename, builder.finish(), opts).unwrap();

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -5,7 +5,7 @@ use crate::AgateOptions;
 use crate::Error;
 use crate::Result;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
-use memmap::{MmapMut, MmapOptions};
+use memmap2::{MmapMut, MmapOptions};
 use prost::{decode_length_delimiter, encode_length_delimiter, length_delimiter_len};
 use std::fs::{File, OpenOptions};
 use std::io::Cursor;
@@ -336,10 +336,11 @@ impl<'a> WalIterator<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempdir::TempDir;
+    use tempfile::tempdir;
+
     #[test]
     fn test_wal_create() {
-        let tmp_dir = TempDir::new("agatedb").unwrap();
+        let tmp_dir = tempdir().unwrap();
         let mut opts = AgateOptions::default();
         opts.value_log_file_size = 4096;
         Wal::open(tmp_dir.path().join("1.wal"), opts).unwrap();
@@ -366,7 +367,7 @@ mod tests {
 
     #[test]
     fn test_wal_iterator() {
-        let tmp_dir = TempDir::new("agatedb").unwrap();
+        let tmp_dir = tempdir().unwrap();
         let mut opts = AgateOptions::default();
         opts.value_log_file_size = 4096;
         let wal_path = tmp_dir.path().join("1.wal");
@@ -391,7 +392,7 @@ mod tests {
 
     #[test]
     fn test_wal_iterator_trunc() {
-        let tmp_dir = TempDir::new("agatedb").unwrap();
+        let tmp_dir = tempdir().unwrap();
         let mut opts = AgateOptions::default();
         opts.value_log_file_size = 4096;
         let wal_path = tmp_dir.path().join("1.wal");


### PR DESCRIPTION
In this PR, we upgraded dependencies with vulnerabilities and replaced unmaintained crates with new ones.

```
Crate:         prost-types
Version:       0.7.0
Title:         Conversion from `prost_types::Timestamp` to `SystemTime` can cause an overflow and panic
Date:          2021-07-08
ID:            RUSTSEC-2021-0073
URL:           https://rustsec.org/advisories/RUSTSEC-2021-0073
Solution:      Upgrade to >=0.8.0
Dependency tree:
prost-types 0.7.0
└── prost-build 0.7.0
    └── proto 0.1.0
        └── agatedb 0.1.0

Crate:         memmap
Version:       0.7.0
Warning:       unmaintained
Title:         memmap is unmaintained
Date:          2020-12-02
ID:            RUSTSEC-2020-0077
URL:           https://rustsec.org/advisories/RUSTSEC-2020-0077
Dependency tree:
memmap 0.7.0
└── agatedb 0.1.0

Crate:         tempdir
Version:       0.3.7
Warning:       unmaintained
error: 1 vulnerability found!
Title:         `tempdir` crate has been deprecated; use `tempfile` instead
Date:          2018-02-13
ID:            RUSTSEC-2018-0017
URL:           https://rustsec.org/advisories/RUSTSEC-2018-0017
Dependency tree:
tempdir 0.3.7
└── agatedb 0.1.0

Crate:         yatp
Version:       0.0.1
Warning:       yanked
Dependency tree:
yatp 0.0.1
└── skiplist 0.1.0
    └── agatedb 0.1.0

warning: 3 allowed warnings found
```

Signed-off-by: Alex Chi <iskyzh@gmail.com>