### PR TITLE
vlog: add parentheses

### DIFF
--- a/src/value_log.rs
+++ b/src/value_log.rs
@@ -249,7 +249,7 @@ impl ValueLog {
                 };
 
                 let orig_meta = entry.meta;
-                entry.meta &= !value::VALUE_FIN_TXN | value::VALUE_TXN;
+                entry.meta &= !(value::VALUE_FIN_TXN | value::VALUE_TXN);
 
                 let plen = Wal::encode_entry(&mut buf, entry);
                 entry.meta = orig_meta;


### PR DESCRIPTION
Signed-off-by: GanZiheng <ganziheng98@gmail.com>

According to https://github.com/dgraph-io/badger/blob/master/value.go#L926 and [Expression precedence](https://doc.rust-lang.org/reference/expressions.html#expression-precedence), parentheses should be added.