### PR TITLE
Shrink unsafe blocks for the Drop impl 

### DIFF
--- a/skiplist/src/arena.rs
+++ b/skiplist/src/arena.rs
@@ -10,9 +10,9 @@ struct ArenaCore {
 
 impl Drop for ArenaCore {
     fn drop(&mut self) {
+        let ptr = self.ptr as *mut u64;
+        let cap = self.cap / 8;
         unsafe {
-            let ptr = self.ptr as *mut u64;
-            let cap = self.cap / 8;
             Vec::from_raw_parts(ptr, 0, cap);
         }
     }

--- a/src/format.rs
+++ b/src/format.rs
@@ -33,8 +33,8 @@ pub fn append_ts(key: &mut BytesMut, ts: u64) {
 
 pub fn get_ts(key: &[u8]) -> u64 {
     let mut ts: u64 = 0;
+    let src = &key[key.len() - 8..];
     unsafe {
-        let src = &key[key.len() - 8..];
         ptr::copy_nonoverlapping(src.as_ptr(), &mut ts as *mut u64 as *mut u8, 8);
     }
     u64::MAX - u64::from_be(ts)


### PR DESCRIPTION
The scope of the unsafe block needs to be as small as possible, and there are fewer areas to focus on when reviewing unsafe-related errors.