### PR TITLE
test: fix table checksum test

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -213,30 +213,22 @@ impl TableInner {
         let mut read_pos = self.table_size;
 
         // read checksum length from last 4 bytes
-        read_pos = read_pos
-            .checked_sub(4)
-            .ok_or_else(|| Error::TableRead("Size of table less than 4.".into()))?;
+        read_pos -= 4;
         let mut buf = self.read(read_pos, 4)?;
         let checksum_len = buf.get_u32() as usize;
 
         // read checksum
-        read_pos = read_pos
-            .checked_sub(checksum_len)
-            .ok_or_else(|| Error::TableRead("Checksum length overflow.".into()))?;
+        read_pos -= checksum_len;
         let buf = self.read(read_pos, checksum_len)?;
         let chksum = Checksum::decode(buf)?;
 
         // read index size from footer
-        read_pos = read_pos
-            .checked_sub(4)
-            .ok_or_else(|| Error::TableRead("Cannot read length of index.".into()))?;
+        read_pos -= 4;
         let mut buf = self.read(read_pos, 4)?;
         self.index_len = buf.get_u32() as usize;
 
         // read index
-        read_pos = read_pos
-            .checked_sub(self.index_len)
-            .ok_or_else(|| Error::TableRead("Index length overflow.".into()))?;
+        read_pos -= self.index_len;
         self.index_start = read_pos;
         let data = self.read(read_pos, self.index_len)?;
         checksum::verify_checksum(&data, &chksum)?;

--- a/src/table.rs
+++ b/src/table.rs
@@ -213,22 +213,30 @@ impl TableInner {
         let mut read_pos = self.table_size;
 
         // read checksum length from last 4 bytes
-        read_pos -= 4;
+        read_pos = read_pos
+            .checked_sub(4)
+            .ok_or_else(|| Error::TableRead("Size of table less than 4.".into()))?;
         let mut buf = self.read(read_pos, 4)?;
         let checksum_len = buf.get_u32() as usize;
 
         // read checksum
-        read_pos -= checksum_len;
+        read_pos = read_pos
+            .checked_sub(checksum_len)
+            .ok_or_else(|| Error::TableRead("Checksum length overflow.".into()))?;
         let buf = self.read(read_pos, checksum_len)?;
         let chksum = Checksum::decode(buf)?;
 
         // read index size from footer
-        read_pos -= 4;
+        read_pos = read_pos
+            .checked_sub(4)
+            .ok_or_else(|| Error::TableRead("Cannot read length of index.".into()))?;
         let mut buf = self.read(read_pos, 4)?;
         self.index_len = buf.get_u32() as usize;
 
         // read index
-        read_pos -= self.index_len;
+        read_pos = read_pos
+            .checked_sub(self.index_len)
+            .ok_or_else(|| Error::TableRead("Index length overflow.".into()))?;
         self.index_start = read_pos;
         let data = self.read(read_pos, self.index_len)?;
         checksum::verify_checksum(&data, &chksum)?;

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -401,9 +401,9 @@ fn test_table_checksum() {
     opts.checksum_mode = ChecksumVerificationMode::OnTableAndBlockRead;
 
     let kv_pairs = generate_table_data(b"k", 10000, opts.clone());
-    let table_data = Bytes::from(build_table_data(kv_pairs, opts.clone()));
+    let table_data = build_table_data(kv_pairs, opts.clone());
 
-    let table = Table::open_in_memory(table_data.clone(), 233, opts.clone()).unwrap();
+    let table = Table::open_in_memory(table_data.clone(), 233, opts).unwrap();
 
     let mut pos = table_data.len() - 4;
     let checksum_length = table_data.slice(pos..pos + 4).get_u32() as usize;

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -1,8 +1,8 @@
 use std::ops::{Deref, DerefMut};
 
 use builder::Builder;
+use bytes::BytesMut;
 use iterator::IteratorError;
-use rand::prelude::*;
 use tempfile::{tempdir, TempDir};
 
 use super::*;
@@ -397,29 +397,31 @@ fn test_table_big_values() {
 
 #[test]
 fn test_table_checksum() {
-    let mut rng = thread_rng();
     let mut opts = get_test_table_options();
     opts.checksum_mode = ChecksumVerificationMode::OnTableAndBlockRead;
+
     let kv_pairs = generate_table_data(b"k", 10000, opts.clone());
-    let table_data = build_table_data(kv_pairs, opts.clone()).to_vec();
-    for _ in 0..10 {
-        let mut table_data = table_data.clone();
-        let x = rng.gen_range(0, table_data.len());
-        let y = rng.gen_range(0, table_data.len());
-        let start = x.min(y);
-        let end = x.max(y);
+    let table_data = Bytes::from(build_table_data(kv_pairs, opts.clone()));
 
-        rng.fill_bytes(&mut table_data[start..end]);
+    let table = Table::open_in_memory(table_data.clone(), 233, opts.clone()).unwrap();
 
-        let result = Table::open_in_memory(Bytes::from(table_data), 233, opts.clone());
-        assert!(result.is_err());
-        if !matches!(result, Err(Error::InvalidChecksum(_))) {
-            println!(
-                "expected invalid checksum error, found {:?}",
-                result.err().unwrap()
-            );
-        }
-    }
+    let mut pos = table_data.len() - 4;
+    let checksum_length = table_data.slice(pos..pos + 4).get_u32() as usize;
+
+    pos -= checksum_length;
+    let checksum = table_data.slice(pos..pos + checksum_length);
+
+    pos -= 4;
+    let index_length = table_data.slice(pos..pos + 4).get_u32() as usize;
+
+    pos -= index_length;
+    let data = table_data.slice(pos..pos + index_length);
+
+    let mut bytes = BytesMut::new();
+    table.inner.index.encode(&mut bytes).unwrap();
+    assert_eq!(data, bytes.freeze());
+
+    checksum::verify_checksum(&data, &Checksum::decode(checksum).unwrap()).unwrap();
 }
 
 fn test_iterator_error_eof() {


### PR DESCRIPTION
`table::tests::test_table_checksum` truncates data of SST randomly and asserts if we read the truncated data, we will get `InvalidChecksum` error. But if checksum length part of data truncated, we may get wrong length value even larger than whole data length while parsing the data, and that will result in subtraction overflow panic.

Signed-off-by: GanZiheng <ganziheng98@gmail.com>