### PR TITLE
memtable: update memtable view

### DIFF
--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -15,8 +15,6 @@ use crate::{
     AgateOptions, Result,
 };
 
-const MEMTABLE_VIEW_MAX: usize = 20;
-
 /// MemTableInner guards WAL and max_version.
 /// These data will only be modified on memtable put.
 /// Therefore, separating wal and max_version enables

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -1,7 +1,5 @@
 use std::{
     collections::VecDeque,
-    mem::{self, ManuallyDrop, MaybeUninit},
-    ptr,
     sync::{atomic::AtomicBool, Arc, RwLock},
 };
 
@@ -153,23 +151,12 @@ impl Drop for MemTable {
 }
 
 pub struct MemTablesView {
-    tables: ManuallyDrop<[Skiplist<Comparator>; MEMTABLE_VIEW_MAX]>,
-    len: usize,
+    tables: Vec<Skiplist<Comparator>>,
 }
 
 impl MemTablesView {
     pub fn tables(&self) -> &[Skiplist<Comparator>] {
-        &self.tables[0..self.len]
-    }
-}
-
-impl Drop for MemTablesView {
-    fn drop(&mut self) {
-        for i in 0..self.len {
-            unsafe {
-                ptr::drop_in_place(&mut self.tables[i]);
-            }
-        }
+        &self.tables[..]
     }
 }
 
@@ -186,17 +173,16 @@ impl MemTables {
     /// Get view of all current memtables
     pub fn view(&self) -> MemTablesView {
         // Maybe flush is better.
-        assert!(self.immutable.len() < MEMTABLE_VIEW_MAX);
-        let mut array: [MaybeUninit<Skiplist<Comparator>>; MEMTABLE_VIEW_MAX] =
-            unsafe { MaybeUninit::uninit().assume_init() };
-        array[0] = MaybeUninit::new(self.mutable.skl.clone());
-        for (i, s) in self.immutable.iter().enumerate() {
-            array[i + 1] = MaybeUninit::new(s.skl.clone());
+        let len = self.immutable.len() + 1;
+
+        let mut tables: Vec<Skiplist<Comparator>> = Vec::with_capacity(len);
+
+        tables.push(self.mutable.skl.clone());
+        for s in self.immutable.iter() {
+            tables.push(s.skl.clone());
         }
-        MemTablesView {
-            tables: unsafe { ManuallyDrop::new(mem::transmute(array)) },
-            len: self.immutable.len() + 1,
-        }
+
+        MemTablesView { tables }
     }
 
     /// Get mutable memtable


### PR DESCRIPTION
Adjust `MemTablesView` to use vector to store all current memtables instead of a fixed length array.

This pull request will also resolve https://github.com/tikv/agatedb/issues/152 from one aspect, which is the count of memtables exceeds `MEMTABLE_VIEW_MAX`.

Signed-off-by: GanZiheng <ganziheng98@gmail.com>