### PR TITLE
workflows: remove org from review-stats

### DIFF
--- a/.github/workflows/review-stats.yml
+++ b/.github/workflows/review-stats.yml
@@ -11,6 +11,5 @@ jobs:
       - name: Run pull request stats
         uses: flowwer-dev/pull-request-stats@master
         with:
-          organization: 'tikv'
           period: 7
           sort-by: 'COMMENTS'


### PR DESCRIPTION
Signed-off-by: zhangjinpeng1987 <zhangjinpeng@pingcap.com>

Remove org from review-stats, or it will grab all members in the organization.