### PR TITLE
levels: don't sync directory in memory mode

### DIFF
--- a/src/levels.rs
+++ b/src/levels.rs
@@ -524,7 +524,10 @@ impl LevelsControllerInner {
             new_tables.append(&mut table?);
         }
 
-        util::sync_dir(&self.opts.dir)?;
+        // To avoid error in memory mode with heavy workload.
+        if !self.opts.in_memory {
+            util::sync_dir(&self.opts.dir)?;
+        }
 
         new_tables.sort_by(|x, y| COMPARATOR.compare_key(x.biggest(), y.biggest()));
 


### PR DESCRIPTION
This will cause problem with heavy workload in memory mode, since we will never return tables built by compaction successfully.

Signed-off-by: GanZiheng <ganziheng98@gmail.com>