### PR TITLE
iterator: uniform behavior and implement `prev` and `to_last` to all Iterators

### DIFF
--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -190,6 +190,22 @@ impl<C: KeyComparator> AgateIterator for SkiplistIterator<C> {
     fn valid(&self) -> bool {
         self.skl_iter.valid()
     }
+
+    fn prev(&mut self) {
+        if !self.reversed {
+            self.skl_iter.prev();
+        } else {
+            self.skl_iter.next();
+        }
+    }
+
+    fn to_last(&mut self) {
+        if !self.reversed {
+            self.skl_iter.seek_to_last();
+        } else {
+            self.skl_iter.seek_to_first();
+        }
+    }
 }
 
 pub struct Iterator<'a> {

--- a/src/iterator_trait.rs
+++ b/src/iterator_trait.rs
@@ -13,4 +13,6 @@ pub trait AgateIterator {
     fn key(&self) -> &[u8];
     fn value(&self) -> Value;
     fn valid(&self) -> bool;
+    fn prev(&mut self);
+    fn to_last(&mut self);
 }

--- a/src/table/iterator.rs
+++ b/src/table/iterator.rs
@@ -472,6 +472,22 @@ impl<T: AsRef<TableInner>> AgateIterator for TableRefIterator<T> {
     fn valid(&self) -> bool {
         self.err.is_none()
     }
+
+    fn prev(&mut self) {
+        if self.opt & ITERATOR_REVERSED == 0 {
+            self.prev_inner();
+        } else {
+            self.next_inner();
+        }
+    }
+
+    fn to_last(&mut self) {
+        if self.opt & ITERATOR_REVERSED == 0 {
+            self.seek_to_last();
+        } else {
+            self.seek_to_first();
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -456,14 +456,45 @@ fn test_iterator_out_of_bound() {
     let opts = get_test_table_options();
     let table = build_test_table(b"key", 1000, opts);
     let mut it = table.new_iterator(0);
+    // next first and then prev
     it.seek_to_last();
     assert!(it.error().is_none());
+
     it.next();
     assert_eq!(it.error(), Some(&IteratorError::Eof));
     it.next();
     assert_eq!(it.error(), Some(&IteratorError::Eof));
+    it.prev();
+    assert!(it.error().is_none());
+
     it.next();
     assert_eq!(it.error(), Some(&IteratorError::Eof));
+    it.next();
+    assert_eq!(it.error(), Some(&IteratorError::Eof));
+    it.prev();
+    assert!(it.error().is_none());
+
+    it.rewind();
+    assert!(it.error().is_none());
+
+    // prev first and then next
+    it.seek_to_first();
+    assert!(it.error().is_none());
+
+    it.prev();
+    assert_eq!(it.error(), Some(&IteratorError::Eof));
+    it.prev();
+    assert_eq!(it.error(), Some(&IteratorError::Eof));
+    it.next();
+    assert!(it.error().is_none());
+
+    it.prev();
+    assert_eq!(it.error(), Some(&IteratorError::Eof));
+    it.prev();
+    assert_eq!(it.error(), Some(&IteratorError::Eof));
+    it.next();
+    assert!(it.error().is_none());
+
     it.rewind();
     assert!(it.error().is_none());
     assert_eq!(user_key(it.key()), key(b"key", 0));
@@ -474,14 +505,45 @@ fn test_iterator_out_of_bound_reverse() {
     let opts = get_test_table_options();
     let table = build_test_table(b"key", 1000, opts);
     let mut it = table.new_iterator(ITERATOR_REVERSED);
+    // next first and then prev
     it.seek_to_first();
     assert!(it.error().is_none());
+
     it.next();
     assert_eq!(it.error(), Some(&IteratorError::Eof));
     it.next();
     assert_eq!(it.error(), Some(&IteratorError::Eof));
+    it.prev();
+    assert!(it.error().is_none());
+
     it.next();
     assert_eq!(it.error(), Some(&IteratorError::Eof));
+    it.next();
+    assert_eq!(it.error(), Some(&IteratorError::Eof));
+    it.prev();
+    assert!(it.error().is_none());
+
+    it.rewind();
+    assert!(it.error().is_none());
+
+    // prev first and then next
+    it.seek_to_last();
+    assert!(it.error().is_none());
+
+    it.prev();
+    assert_eq!(it.error(), Some(&IteratorError::Eof));
+    it.prev();
+    assert_eq!(it.error(), Some(&IteratorError::Eof));
+    it.next();
+    assert!(it.error().is_none());
+
+    it.prev();
+    assert_eq!(it.error(), Some(&IteratorError::Eof));
+    it.prev();
+    assert_eq!(it.error(), Some(&IteratorError::Eof));
+    it.next();
+    assert!(it.error().is_none());
+
     it.rewind();
     assert!(it.error().is_none());
     assert_eq!(user_key(it.key()), key(b"key", 999));


### PR DESCRIPTION
Signed-off-by: GanZiheng <ganziheng98@gmail.com>

Uniform all kinds of iterators which implement the `AgateIterator` trait.

Suppose we have another two extra elements in the data which the iterator iterates over, one is before the original first element, called `before first`, and another is after the last original element, namely `after last`.

1. If we arrives the first element, and call `prev`, we will arrive `before first`, and `valid` will return false;
2. If we arrives the last element, and call `next`, we will arrive `after last`, and `valid` will return false;
3. At `before first`, if  we call `prev`, nothing will change, and if we call `next`, we will move to the first element;
4. At `after last`, if  we call `next`, nothing will change, and if we call `prev`, we will move to the last element;