### PR TITLE
level: fix index in move_l0_to_front

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ rocksdb = { version = "0.15", optional = true }
 skiplist = { path = "skiplist" }
 tempdir = "0.3"
 thiserror = "1.0"
-yatp = { git = "https://github.com/tikv/yatp.git" }
+yatp = { git = "https://github.com/tikv/yatp.git", rev = "b793461ea4abd202798cda6e20e97a054103f2ad" }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/agate_bench/Cargo.toml
+++ b/agate_bench/Cargo.toml
@@ -17,7 +17,7 @@ rand = "0.7"
 rocksdb = { version = "0.15", optional = true }
 tempdir = "0.3"
 threadpool = "1.8"
-yatp = { git = "https://github.com/tikv/yatp.git" }
+yatp = { git = "https://github.com/tikv/yatp.git", rev = "b793461ea4abd202798cda6e20e97a054103f2ad" }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.4.0"

--- a/skiplist/Cargo.toml
+++ b/skiplist/Cargo.toml
@@ -10,7 +10,7 @@ rand = "0.7"
 
 [dev-dependencies]
 criterion = "0.3"
-yatp = { git = "https://github.com/tikv/yatp.git" }
+yatp = { git = "https://github.com/tikv/yatp.git", rev = "b793461ea4abd202798cda6e20e97a054103f2ad" }
 
 [target.'cfg(not(target_env = "msvc"))'.dev-dependencies]
 tikv-jemallocator = "0.4.0"

--- a/skiplist/src/arena.rs
+++ b/skiplist/src/arena.rs
@@ -58,7 +58,7 @@ impl Arena {
             if grow_by < size {
                 grow_by = size;
             }
-            let mut new_buf: Vec<u64> = Vec::with_capacity((self.cap.get() + grow_by) as usize / 8);
+            let mut new_buf: Vec<u64> = Vec::with_capacity((self.cap.get() + grow_by) / 8);
             let new_ptr = new_buf.as_mut_ptr() as *mut u8;
             unsafe {
                 ptr::copy_nonoverlapping(new_ptr, self.ptr.get(), self.cap.get());

--- a/skiplist/tests/tests.rs
+++ b/skiplist/tests/tests.rs
@@ -51,14 +51,14 @@ fn test_basic() {
     ];
 
     for (key, value) in &table {
-        list.put(key_with_ts(*key, 0), value.clone());
+        list.put(key_with_ts(key, 0), value.clone());
     }
 
     assert_eq!(list.get(&key_with_ts("key", 0)), None);
     assert_eq!(list.len(), 5);
     assert!(!list.is_empty());
     for (key, value) in &table {
-        let get_key = key_with_ts(*key, 0);
+        let get_key = key_with_ts(key, 0);
         assert_eq!(list.get(&get_key), Some(value), "{}", key);
     }
 }

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -1003,8 +1003,8 @@ impl LevelsController {
                 |prios: Vec<CompactionPriority>| match prios.iter().position(|x| x.level == 0) {
                     Some(pos) => {
                         let mut result = vec![prios[pos].clone()];
-                        result.extend_from_slice(&prios[..idx]);
-                        result.extend_from_slice(&prios[idx + 1..]);
+                        result.extend_from_slice(&prios[..pos]);
+                        result.extend_from_slice(&prios[pos + 1..]);
                         result
                     }
                     _ => prios,

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -422,7 +422,7 @@ mod tests {
                 .read(true)
                 .write(true)
                 .create(true)
-                .open(&path)
+                .open(path)
                 .unwrap();
             file.write_at(&[b'G'], offset).unwrap();
         }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -87,7 +87,7 @@ impl Manifest {
         let file_len = file.metadata()?.len();
 
         let mut file = BufReader::new(file);
-        file.seek(SeekFrom::Start(0))?;
+        file.rewind()?;
         let mut magic_buf = vec![0; 8];
         file.read_exact(&mut magic_buf)?;
         if &magic_buf[..4] != MAGIC_TEXT {

--- a/src/ops/transaction.rs
+++ b/src/ops/transaction.rs
@@ -99,7 +99,7 @@ impl Transaction {
 
     fn check_size(&mut self, entry: &Entry) -> Result<()> {
         let count = self.count + 1;
-        let size = self.size + entry.estimate_size(self.core.opts.value_threshold) as usize + 10;
+        let size = self.size + entry.estimate_size(self.core.opts.value_threshold) + 10;
 
         if count >= self.core.opts.max_batch_count as usize
             || size >= self.core.opts.max_batch_size as usize
@@ -458,7 +458,7 @@ impl AgateIterator for PendingWritesIterator {
         let key = user_key(key);
         self.next_idx = crate::util::search(self.entries.len(), |idx| {
             // Should not use COMPARATOR when compare without ts.
-            let cmp = (&self.entries[idx].key[..]).cmp(key);
+            let cmp = (self.entries[idx].key[..]).cmp(key);
             if !self.reversed {
                 cmp != Less
             } else {

--- a/src/table.rs
+++ b/src/table.rs
@@ -475,7 +475,7 @@ impl TableInner {
                 .load(std::sync::atomic::Ordering::SeqCst)
             {
                 drop(file);
-                fs::remove_file(&name)?;
+                fs::remove_file(name)?;
             }
         }
         Ok(())

--- a/src/table/iterator.rs
+++ b/src/table/iterator.rs
@@ -111,7 +111,7 @@ impl BlockIterator {
         }
 
         self.err = None;
-        let start_offset = self.entry_offsets()[i] as u32;
+        let start_offset = self.entry_offsets()[i];
 
         if self.base_key.is_empty() {
             let mut base_header = Header::default();
@@ -128,7 +128,7 @@ impl BlockIterator {
             self.entry_offsets()[self.idx + 1] as usize
         };
 
-        let mut entry_data = self.data.slice(start_offset as usize..end_offset as usize);
+        let mut entry_data = self.data.slice(start_offset as usize..end_offset);
         let mut header = Header::default();
         header.decode(&mut entry_data);
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -28,7 +28,7 @@ unsafe fn u32(ptr: *const u8) -> u32 {
 }
 
 #[inline]
-pub fn bytes_diff<'a, 'b>(base: &'a [u8], target: &'b [u8]) -> &'b [u8] {
+pub fn bytes_diff<'a>(base: &[u8], target: &'a [u8]) -> &'a [u8] {
     let end = cmp::min(base.len(), target.len());
     let mut i = 0;
     unsafe {
@@ -82,7 +82,7 @@ pub fn same_key(a: &[u8], b: &[u8]) -> bool {
 }
 
 pub fn unix_time() -> u64 {
-    coarsetime::Clock::now_since_epoch().as_millis() as u64
+    coarsetime::Clock::now_since_epoch().as_millis()
 }
 
 pub fn has_any_prefixes(s: &[u8], list_of_prefixes: &[Bytes]) -> bool {

--- a/src/value.rs
+++ b/src/value.rs
@@ -29,7 +29,7 @@ pub struct Value {
 impl From<Value> for Bytes {
     fn from(value: Value) -> Bytes {
         // TODO: we can reduce unnecessary copy by re-writing `encode`
-        let mut buf = BytesMut::with_capacity(value.encoded_size() as usize);
+        let mut buf = BytesMut::with_capacity(value.encoded_size());
         value.encode(&mut buf);
         buf.freeze()
     }

--- a/src/value_log.rs
+++ b/src/value_log.rs
@@ -370,7 +370,7 @@ mod tests {
         let val1 = b"sampleval012345678901234567890123";
         let val2 = b"samplevalb012345678901234567890123";
 
-        assert!(val1.len() > opts.value_threshold as usize);
+        assert!(val1.len() > opts.value_threshold);
 
         let mut e1 = Entry::new(
             Bytes::from_static(b"samplekey"),


### PR DESCRIPTION
move_l0_to_front moves level0 to the front, and the others remain unchanged.
But it use 'idx' not 'pos'