### PR TITLE
Fix build error on rust 1.9.20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
         name: Checkout 🛎️
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin
@@ -63,7 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         name: Checkout 🛎️
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -350,7 +350,9 @@ fn test_uni_iterator() {
 // TODO: concat iterators and merge iterators
 
 fn value(i: usize) -> Bytes {
-    Bytes::from(format!("{:01048576}", i)) // 1MB value
+    let mut result = i.to_string().into_bytes();
+    result.resize(1048576, 0);
+    result.into()
 }
 
 #[test]


### PR DESCRIPTION
Fix the belowing build error on rust 1.92.0.

  error: invalid format string: integer `1048576` does not fit into the
  type `u16` whose range is `0..=65535`
     --> src/table/tests.rs:353:29